### PR TITLE
feat: Add user authentication to request object in AuthBearer(#122)

### DIFF
--- a/django/a_apis/auth/bearer.py
+++ b/django/a_apis/auth/bearer.py
@@ -1,12 +1,17 @@
 from ninja.security import HttpBearer
-from rest_framework_simplejwt.exceptions import TokenError
 from rest_framework_simplejwt.tokens import AccessToken
+
+from django.contrib.auth import get_user_model
+
+User = get_user_model()
 
 
 class AuthBearer(HttpBearer):
     def authenticate(self, request, token):
         try:
-            AccessToken(token)
+            access_token = AccessToken(token)
+            user = User.objects.get(id=access_token["user_id"])
+            request.user = user
             return token
-        except TokenError:
+        except Exception:
             return None


### PR DESCRIPTION
수정파일: `django/a_apis/auth/bearer.py`

수정내용:
- `from rest_framework_simplejwt.exceptions import TokenError` 제거
- `from django.contrib.auth import get_user_model` 추가
- `User = get_user_model()` 추가
- `AccessToken(token)` → `access_token = AccessToken(token)`
- `user = User.objects.get(id=access_token["user_id"])` 추가
- `request.user = user` 추가
- `except TokenError:` → `except Exception:`

특이사항:
- 유저 인증이 추가되어 request 객체에서 사용자를 쉽게 접근할 수 있게 했습니다.
- 예외 처리에서 `TokenError` 대신 일반 `Exception`을 사용하도록 변경했습니다.