### PR TITLE
Fix : file_path 파일경로 100자 over 오류 개선(#128)

### DIFF
--- a/django/a_apis/service/products.py
+++ b/django/a_apis/service/products.py
@@ -1,4 +1,5 @@
 import os
+import uuid
 from typing import Optional
 
 import boto3
@@ -83,7 +84,8 @@ class ProductService:
             image_urls = []
             for image in images:
                 # S3에 파일 업로드
-                file_path = f"products/images/{image.name}"
+                file_extension = image.name.split(".")[-1]
+                file_path = f"products/images/{str(uuid.uuid4())[:8]}.{file_extension}"
                 saved_path = default_storage.save(file_path, image)
                 image_url = default_storage.url(saved_path)
                 image_urls.append(image_url)
@@ -206,7 +208,10 @@ class ProductService:
                     image_urls = []
                     for image in images:
                         # S3에 새 이미지 업로드
-                        file_path = f"products/images/{image.name}"
+                        file_extension = image.name.split(".")[-1]
+                        file_path = (
+                            f"products/images/{str(uuid.uuid4())[:8]}.{file_extension}"
+                        )
                         saved_path = default_storage.save(file_path, image)
                         image_url = default_storage.url(saved_path)
                         image_urls.append(image_url)


### PR DESCRIPTION
### 수정 파일 목록
- `django/a_apis/service/products.py`

### 수정 내용
```diff
+ import uuid
```
```diff
- file_path = f"products/images/{image.name}"
+ file_extension = image.name.split(".")[-1]
+ file_path = f"products/images/{str(uuid.uuid4())[:8]}.{file_extension}"
```
```diff
- file_path = f"products/images/{image.name}"
+ file_extension = image.name.split(".")[-1]
+ file_path = f"products/images/{str(uuid.uuid4())[:8]}.{file_extension}"
```

### 특이사항
- 이미지 파일 경로 생성 시 파일 이름 대신 UUID를 사용하여 고유한 파일 이름을 생성하도록 수정되었습니다.
- file_path 100자 초과해서 수정함