### PR TITLE
Feat : 나의찜매물 GET API 개발(#147)

### DIFF
--- a/django/a_apis/api/products.py
+++ b/django/a_apis/api/products.py
@@ -8,6 +8,7 @@ from a_apis.schema.products import (
     ProductAllSchema,
     ProductLikeResponseSchema,
     ProductUpdateResponseSchema,
+    UserLikedProductsResponseSchema,
 )
 from a_apis.service.products import ProductService
 from ninja import Body, File, Router
@@ -119,6 +120,42 @@ def toggle_like_product(
         response_data = ProductService.toggle_like_product(user, product_id)
         return response_data
 
+    except HttpError as e:
+        return Response({"success": False, "message": str(e)}, status=e.status_code)
+    except Exception as e:
+        return Response(
+            {"success": False, "message": "서버 오류가 발생했습니다."}, status=500
+        )
+
+
+@router.get("/like-mylist", response=UserLikedProductsResponseSchema)
+@login_required
+def mylist_like_products(request):
+    """
+    사용자가 찜한 매물 목록 조회 API
+    ```
+    Args:
+        request: Django 요청 객체
+
+    Returns:
+        UserLikedProductsResponseSchema: 찜한 매물 목록 조회 결과
+        - success: bool (요청 처리 성공 여부)
+        - message: str (응답 메시지)
+        - total_count: int (전체 찜한 매물 수)
+        - products: list[UserLikedProductsSchema] (찜한 매물 목록)
+            - product_id: int (매물 ID)
+            - pro_title: str (매물 제목)
+            - pro_price: int (매물 가격)
+            - pro_type: str (건물 유형)
+            - pro_supply_a: float (공급면적)
+            - pro_address: str (매물 도로명주소)
+            - image_url: str (매물 이미지 URL - 첫 번째 이미지)
+            - created_at: datetime (찜한 시간)
+    ```
+    """
+    try:
+        response_data = ProductService.mylist_like_products(request.user)
+        return response_data
     except HttpError as e:
         return Response({"success": False, "message": str(e)}, status=e.status_code)
     except Exception as e:

--- a/django/a_apis/schema/products.py
+++ b/django/a_apis/schema/products.py
@@ -94,3 +94,23 @@ class ProductLikeResponseSchema(Schema):
     created_at: Optional[datetime] = Field(
         None, description="찜하기 생성 시간"
     )  # None 허용
+
+
+class UserLikedProductsSchema(Schema):
+    product_id: int = Field(..., description="매물 ID")
+    pro_title: str = Field(..., description="매물 제목")
+    pro_price: int = Field(..., description="매물 가격")
+    pro_type: str = Field(..., description="건물 유형")
+    pro_supply_a: float = Field(..., description="공급면적")
+    pro_address: str = Field(..., description="매물 주소(도로명)")
+    image_url: Optional[str] = Field(
+        None, description="매물 이미지 URL(첫 번째 이미지)"
+    )
+    created_at: datetime = Field(..., description="찜한 시간")
+
+
+class UserLikedProductsResponseSchema(Schema):
+    success: bool = Field(..., description="요청 처리 성공 여부")
+    message: str = Field(..., description="응답 메시지")
+    total_count: int = Field(..., description="전체 찜한 매물 수")
+    products: list[UserLikedProductsSchema] = Field(..., description="찜한 매물 목록")


### PR DESCRIPTION
### 수정목록
- **파일**: `django/a_apis/api/products.py`
- **파일**: `django/a_apis/schema/products.py`
- **파일**: `django/a_apis/service/products.py`

### 수정내용
- **`django/a_apis/api/products.py`**:
  - 새로운 API 엔드포인트 `/like-mylist` 추가하여 사용자가 찜한 매물 목록 조회 기능 추가.
  - `mylist_like_products` 함수 추가하여 사용자가 찜한 매물 목록을 반환하도록 구현.
  
- **`django/a_apis/schema/products.py`**:
  - 새로운 스키마 `UserLikedProductsSchema` 및 `UserLikedProductsResponseSchema` 추가.
  - `UserLikedProductsSchema`는 매물 ID, 제목, 가격, 유형, 공급면적, 주소, 이미지 URL 및 찜한 시간 포함.
  - `UserLikedProductsResponseSchema`는 요청 성공 여부, 응답 메시지, 전체 찜한 매물 수 및 매물 목록 포함.

- **`django/a_apis/service/products.py`**:
  - `UserLikedProductsResponseSchema` 및 `UserLikedProductsSchema` 임포트 추가.
  - 새로운 정적 메서드 `mylist_like_products` 추가하여 사용자가 찜한 매물 목록을 조회하는 서비스 추가.


### 특이사항
- 새로운 API 엔드포인트 `/like-mylist`가 추가되어 사용자가 찜한 매물 목록을 조회 가능
- 사용자 인증 여부를 확인하여 인증되지 않은 사용자는 401 상태 코드와 함께 "로그인이 필요합니다." 메시지를 반환하도록 구현.
- 찜한 매물 목록 조회 시 서버 오류가 발생하면 500 상태 코드와 함께 오류 메시지를 반환하도록 처리.