### PR TITLE
Chore : 찜한매물없을 경우 200 정상응답값으로 수정(#153)

### DIFF
--- a/django/a_apis/api/products.py
+++ b/django/a_apis/api/products.py
@@ -2,6 +2,7 @@ import logging
 from typing import Optional
 
 from a_apis.auth.bearer import AuthBearer
+from a_apis.models import ProductDetail
 from a_apis.schema.products import (
     ProductAllResponseSchema,
     ProductAllSchema,
@@ -16,7 +17,6 @@ from ninja.files import UploadedFile
 from ninja.responses import Response
 from ninja.security import django_auth
 
-from a_apis.models import ProductDetail
 from django.contrib.auth.decorators import login_required
 
 logger = logging.getLogger(__name__)

--- a/django/a_apis/service/products.py
+++ b/django/a_apis/service/products.py
@@ -365,6 +365,15 @@ class ProductService:
                 .order_by("-created_at")
             )
 
+            # 찜한 매물이 없는 경우도 정상 응답
+            if not liked_products.exists():
+                return UserLikedProductsResponseSchema(
+                    success=True,
+                    message="찜한 매물이 없습니다.",
+                    total_count=0,
+                    products=[],
+                )
+
             products_data = []
             for like in liked_products:
                 # 첫 번째 이미지를 가져오기


### PR DESCRIPTION
### 수정목록
- **파일**: `django/a_apis/service/products.py`

- **`django/a_apis/service/products.py`**:
  - `mylist_like_products` 함수에 찜한 매물이 없는 경우를 처리하는 로직 추가.
  - 찜한 매물이 없을 경우 정상 응답을 반환하도록 수정.

### 특이사항
- `mylist_like_products` 함수에서 찜한 매물이 없는 경우에도 성공 응답을 반환하도록 개선.