### PR TITLE
Chore : 매물관련API 수정(#156)

### DIFF
--- a/django/a_apis/schema/products.py
+++ b/django/a_apis/schema/products.py
@@ -75,6 +75,8 @@ class ProductAllResponseSchema(Schema):
     video: Optional[str] = None
     detail: ProductDetailSchema
     address: AddressSchema
+    created_at: datetime = Field(..., description="등록일")
+    updated_at: datetime = Field(..., description="수정일")
 
 
 class ProductUpdateResponseSchema(Schema):
@@ -85,6 +87,8 @@ class ProductUpdateResponseSchema(Schema):
     video: Optional[str] = None
     detail: ProductDetailSchema
     address: AddressSchema
+    created_at: datetime = Field(..., description="등록일")
+    updated_at: datetime = Field(..., description="수정일")
 
 
 class ProductLikeResponseSchema(Schema):

--- a/django/a_apis/service/products.py
+++ b/django/a_apis/service/products.py
@@ -139,6 +139,8 @@ class ProductService:
                 video=response_data["video"],
                 detail=response_data["detail"],
                 address=response_data["address"],
+                created_at=product_detail.created_at,
+                updated_at=product_detail.updated_at,
             )
 
         except ValueError as e:
@@ -289,6 +291,8 @@ class ProductService:
                     video=response_data["video"],
                     detail=response_data["detail"],
                     address=response_data["address"],
+                    created_at=product_detail.created_at,
+                    updated_at=product_detail.updated_at,
                 )
 
         except ValueError as e:
@@ -367,11 +371,14 @@ class ProductService:
 
             # 찜한 매물이 없는 경우도 정상 응답
             if not liked_products.exists():
-                return UserLikedProductsResponseSchema(
-                    success=True,
-                    message="찜한 매물이 없습니다.",
-                    total_count=0,
-                    products=[],
+                return Response(
+                    {
+                        "success": True,
+                        "message": "찜한 매물이 없습니다.",
+                        "total_count": 0,
+                        "products": [],
+                    },
+                    status=400,
                 )
 
             products_data = []


### PR DESCRIPTION
수정된 파일:
1. `django/a_apis/schema/products.py`
2. `django/a_apis/service/products.py`

수정 내용:

1. `django/a_apis/schema/products.py`:
   - `ProductAllResponseSchema` 클래스:
     - `created_at` 필드 추가: `created_at: datetime = Field(..., description="등록일")`
     - `updated_at` 필드 추가: `updated_at: datetime = Field(..., description="수정일")`
   - `ProductUpdateResponseSchema` 클래스:
     - `created_at` 필드 추가: `created_at: datetime = Field(..., description="등록일")`
     - `updated_at` 필드 추가: `updated_at: datetime = Field(..., description="수정일")`

2. `django/a_apis/service/products.py`:
   - `create_product` 함수:
     - `created_at` 필드 추가: `created_at=product_detail.created_at`
     - `updated_at` 필드 추가: `updated_at=product_detail.updated_at`
   - `update_product` 함수:
     - `created_at` 필드 추가: `created_at=product_detail.created_at`
     - `updated_at` 필드 추가: `updated_at=product_detail.updated_at`
   - `mylist_like_products` 함수:
     - 찜한 매물이 없는 경우 반환 형식 수정:
       ```python
       return Response(
           {
               "success": True,
               "message": "찜한 매물이 없습니다.",
               "total_count": 0,
               "products": [],
           },
           status=400,
       )
       ```

특이사항:
- `created_at`와 `updated_at` 필드가 여러 스키마와 서비스 함수에 추가됨.
- `mylist_like_products` 함수에서 빈 찜한 매물이 있을 경우 반환 형식이 `UserLikedProductsResponseSchema`에서 `Response`로 변경되고, 상태 코드가 400으로 설정됨.