### PR TITLE
157 fix add number in social login

### DIFF
--- a/django/a_apis/api/products.py
+++ b/django/a_apis/api/products.py
@@ -2,7 +2,6 @@ import logging
 from typing import Optional
 
 from a_apis.auth.bearer import AuthBearer
-from a_apis.models import ProductDetail
 from a_apis.schema.products import (
     ProductAllResponseSchema,
     ProductAllSchema,
@@ -17,6 +16,7 @@ from ninja.files import UploadedFile
 from ninja.responses import Response
 from ninja.security import django_auth
 
+from a_apis.models import ProductDetail
 from django.contrib.auth.decorators import login_required
 
 logger = logging.getLogger(__name__)

--- a/django/a_apis/schema/auth.py
+++ b/django/a_apis/schema/auth.py
@@ -11,6 +11,7 @@ class TokenSchema(Schema):
 class UserSchema(Schema):
     email: str
     username: Optional[str] = None
+    phone_number: Optional[str] = None
     is_active: Optional[bool] = None
     is_email_verified: Optional[bool] = None
     is_social_login: Optional[bool] = None

--- a/django/a_apis/service/auth.py
+++ b/django/a_apis/service/auth.py
@@ -12,13 +12,16 @@ User = get_user_model()
 
 class SocialLoginService:
     @staticmethod
-    def create_or_get_user(email: str, username: str, social_type: str) -> User:
+    def create_or_get_user(
+        email: str, username: str, social_type: str, phone_number: str
+    ) -> User:
         user, created = User.objects.get_or_create(
             email=email,
             defaults={
                 "username": username,
                 "is_email_verified": True,
                 "is_social_login": True,
+                "phone_number": phone_number,
             },
         )
 
@@ -176,6 +179,7 @@ class KakaoAuthService:
         }
 
         user_info_resp = requests.get(user_info_url, headers=headers)
+
         if user_info_resp.status_code != 200:
             raise HttpError(400, "카카오에서 사용자 정보를 가져오는데 실패했습니다")
 
@@ -272,9 +276,13 @@ class NaverAuthService:
             raise HttpError(400, "이메일 정보가 없습니다")
 
         username = response.get("name", "")
+        phone_number = response.get("mobile", "")  # 네이버에서 제공하는 전화번호
 
         user = SocialLoginService.create_or_get_user(
-            email=email, username=username, social_type="naver"
+            email=email,
+            username=username,
+            social_type="naver",
+            phone_number=phone_number,
         )
         refresh = RefreshToken.for_user(user)
 
@@ -285,6 +293,7 @@ class NaverAuthService:
             "user": {
                 "email": user.email,
                 "username": user.username,
+                "phone_number": user.phone_number,
                 "is_active": user.is_active,
                 "is_email_verified": user.is_email_verified,
                 "is_social_login": user.is_social_login,


### PR DESCRIPTION
### 수정파일:
- `django/a_apis/api/products.py`
- `django/a_apis/schema/auth.py`
- `django/a_apis/service/auth.py`

### 수정내용:
- **`django/a_apis/api/products.py`**:
  - `ProductDetail` import 위치 이동: 파일 상단에서 중간으로 이동되었습니다.
- **`django/a_apis/schema/auth.py`**:
  - `UserSchema`에 `phone_number` 필드 추가: 선택적 필드로 전화번호를 추가했습니다.
- **`django/a_apis/service/auth.py`**:
  - `create_or_get_user` 메서드 수정: `phone_number` 매개변수를 추가했습니다.
  - `callback_naver_auth` 메서드 수정: 네이버 응답에서 전화번호를 받아와 `User` 생성 시 사용하도록 수정되었습니다.

### 특이사항:
- 구글 - 전하번호 못받음.
- 카카오 - 개인정보 받을수있게 신청함. (3~5일소요)
- 네이버 - 최초로그인시 전화번호 표시.