### PR TITLE
feat: Add WebSocket support in Nginx configuration

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -69,9 +69,27 @@ http {
             alias /app/media/;
         }
 
+        location /ws/ {
+            proxy_pass http://web_backend;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_read_timeout 86400;  # 웹소켓 연결 타임아웃 설정
+        }
+
         error_page 500 502 503 504 /50x.html;
         location = /50x.html {
             root /usr/share/nginx/html;
         }
+    }
+
+    # WebSocket 설정
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        '' close;
     }
 }


### PR DESCRIPTION
- Introduced a new location block for WebSocket connections at /ws/ with appropriate proxy settings.
- Configured headers to support WebSocket upgrades and maintain client information.
- Set a long read timeout for WebSocket connections to ensure stability.
- Added a mapping for connection upgrades to handle WebSocket connections effectively.