### PR TITLE
Chore : Refactor - Product Schema/Service/Api-(#209)

### DIFF
--- a/django/a_apis/api/products.py
+++ b/django/a_apis/api/products.py
@@ -4,12 +4,14 @@ from typing import List, Optional
 from a_apis.auth.bearer import AuthBearer
 from a_apis.models import ProductDetail
 from a_apis.schema.products import (
+    ProductRequestBodySchema,  # ProductAllSchema -> ProductRequestBodySchema로 변경
+)
+from a_apis.schema.products import (
+    MyProductsSchemaResponseSchema,
     ProductAllResponseSchema,
-    ProductAllSchema,
     ProductLikeResponseSchema,
     ProductUpdateResponseSchema,
     UserLikedProductsResponseSchema,
-    UserProductsResponseSchema,
 )
 from a_apis.service.products import ProductService
 from ninja import Body, File, Router
@@ -30,26 +32,36 @@ public_router = Router()
 @login_required
 def create_product(
     request,
-    data: ProductAllSchema,
+    data: ProductRequestBodySchema,
     images: list[UploadedFile] = File(...),
     video: Optional[UploadedFile] = File(None),
 ):
     """
     매물 등록 API
     ```
-    Note:
-        - management_cost: 관리비가 있는 경우에만 포함, 없는 경우 필드 자체를 생략하면 null로 저장
-        - sale: 항상 true로 저장되므로 요청 시 생략 가능
-        ```
-
     Args:
         request: Django 요청 객체
-        data (ProductAllSchema): 생성할 매물의 데이터
-        images (list[UploadedFile]): 업로드할 이미지 파일 목록
-        video (Optional[UploadedFile]): 업로드할 동영상 파일 (없을 수도 있음)
+        data (ProductRequestBodySchema): 생성할 매물의 데이터
+        images (list[UploadedFile]): 업로드할 이미지 파일 목록 (최대 10장)
+        video (Optional[UploadedFile]): 업로드할 동영상 파일 (선택사항)
 
     Returns:
         ProductAllResponseSchema: 생성된 매물 응답 데이터
+        - success: bool (생성 성공 여부)
+        - message: str (응답 메시지)
+        - product: ProductResponseDetailSchema
+            - product_id: int (매물 ID)
+            - images: list[str] (이미지 URL 목록)
+            - video: Optional[str] (동영상 URL)
+            - pro_title: str (매물 제목)
+            - ... (기타 매물 상세 정보)
+            - created_at: datetime (등록일)
+            - updated_at: datetime (수정일)
+
+    Note:
+        - management_cost: Optional[int] - 관리비가 있는 경우에만 포함
+        - sale: Optional[bool] - 기본값 True
+    ```
     """
     try:
         user = request.user
@@ -68,16 +80,37 @@ def create_product(
 def update_product(
     request,
     product_id: int,
-    data: ProductAllSchema,
+    data: ProductRequestBodySchema,
     images: list[UploadedFile] = File(None),
     video: Optional[UploadedFile] = File(None),
 ):
     """
     매물 수정 API
     ```
-     Note:
-        - management_cost: 관리비가 있는 경우에만 포함, 없는 경우 필드 자체를 생략하면 null로 저장
-        - sale: 항상 true로 저장되므로 요청 시 생략 가능
+    Args:
+        request: Django 요청 객체
+        product_id (int): 수정할 매물 ID
+        data (ProductRequestBodySchema): 수정할 매물 데이터
+        images (list[UploadedFile]): 새로 업로드할 이미지 파일 목록 (선택사항)
+        video (Optional[UploadedFile]): 새로 업로드할 동영상 파일 (선택사항)
+
+    Returns:
+        ProductUpdateResponseSchema: 수정된 매물 응답 데이터
+        - success: bool (수정 성공 여부)
+        - message: str (응답 메시지)
+        - product: ProductUpdateResponseDetailSchema
+            - product_id: int (매물 ID)
+            - images: list[str] (이미지 URL 목록)
+            - video: Optional[str] (동영상 URL)
+            - pro_title: str (매물 제목)
+            - ... (기타 매물 상세 정보)
+            - created_at: datetime (등록일)
+            - updated_at: datetime (수정일)
+
+    Note:
+        - management_cost: Optional[int] - 관리비가 있는 경우에만 포함
+        - sale: Optional[bool] - 기본값 True
+        - images나 video를 제공하지 않으면 기존 파일 유지
     ```
     """
     try:
@@ -149,8 +182,8 @@ def mylist_like_products(request):
             - pro_price: int (매물 가격)
             - pro_type: str (건물 유형)
             - pro_supply_a: float (공급면적)
-            - pro_address: str (매물 도로명주소)
-            - image_url: str (매물 이미지 URL - 첫 번째 이미지)
+            - add_new: str (매물 도로명주소)
+            - images: Optional[str] (매물 대표 이미지 URL -첫 번째 이미지 사용)
             - created_at: datetime (찜한 시간)
     ```
     """
@@ -165,7 +198,7 @@ def mylist_like_products(request):
         )
 
 
-@router.get("/products-mylist", response=UserProductsResponseSchema)
+@router.get("/products-mylist", response=MyProductsSchemaResponseSchema)
 @login_required
 def mylist_products(request):
     """
@@ -175,35 +208,19 @@ def mylist_products(request):
         request: Django 요청 객체
 
     Returns:
-        UserProductsResponseSchema: 등록한 매물 목록 조회 결과
+        MyProductsSchemaResponseSchema: 등록한 매물 목록 조회 결과
         - success: bool (요청 처리 성공 여부)
         - message: str (응답 메시지)
         - total_count: int (전체 등록 매물 수)
-        - products: list[ProductDetailResponseSchema] (등록한 매물 목록)
+        - products: list[MyProductsSchema] (등록한 매물 목록)
             - product_id: int (매물 ID)
-            - images: list[str] (이미지 URL 목록)
-            - video: Optional[str] (동영상 URL)
-            - detail: ProductDetailSchema (매물 상세 정보)
-                - pro_title: str (매물 제목)
-                - pro_price: int (매물 가격)
-                - management_cost: Optional[int] (관리비)
-                - pro_supply_a: float (공급면적)
-                - pro_site_a: float (부지면적)
-                - pro_heat: str (난방방식)
-                - pro_type: str (건물유형)
-                - pro_floor: int (층수)
-                - pro_rooms: int (방 개수)
-                - pro_bathrooms: int (욕실 개수)
-                - pro_construction_year: int (건축연도)
-                - description: str (상세설명)
-                - sale: bool (판매여부)
-            - address: AddressSchema (주소 정보)
-                - add_new: str (도로명주소)
-                - add_old: str (구주소)
-                - latitude: float (위도)
-                - longitude: float (경도)
-            - created_at: datetime (등록일)
-            - updated_at: datetime (수정일)
+            - pro_title: str (매물 제목)
+            - pro_price: int (매물 가격)
+            - pro_type: str (건물 유형)
+            - pro_supply_a: float (공급면적)
+            - add_new: str (매물 도로명주소)
+            - images: Optional[str] (매물 대표 이미지 URL - 첫번째 이미지 사용)
+            - created_at: datetime (등록 시간)
     ```
     """
     try:

--- a/django/a_apis/schema/products.py
+++ b/django/a_apis/schema/products.py
@@ -6,19 +6,6 @@ from ninja import Field, Schema
 from ninja.files import UploadedFile
 
 
-class AddressSchema(Schema):
-    add_new: str = Field(..., description="도로명주소")
-    add_old: str = Field(..., description="구주소")
-    latitude: float = Field(..., description="위도")
-    longitude: float = Field(..., description="경도")
-
-
-class AddressResponseSchema(Schema):
-    success: bool
-    message: str
-    data: Optional[AddressSchema] = None
-
-
 class HeatType(str, Enum):
     GAS = "gas"
     OIL = "oil"
@@ -32,12 +19,11 @@ class BuildingType(str, Enum):
     TYPE_ETC = "type_etc"
 
 
-class ProductDetailSchema(Schema):
+# 매물 등록/수정 api request 스키마
+class ProductRequestBodySchema(Schema):
     pro_title: str = Field(..., description="제목")
     pro_price: int = Field(..., description="매물금액")
-    management_cost: Optional[int] = Field(
-        default=None, description="관리비"
-    )  # sale을 선택적 필드로 변경하고 기본값을 None으로 설정
+    management_cost: Optional[int] = Field(default=None, description="관리비")
     pro_supply_a: float = Field(..., description="공급면적(평수)")
     pro_site_a: float = Field(..., description="부지면적")
     pro_heat: HeatType = Field(..., description="난방방식")
@@ -50,47 +36,79 @@ class ProductDetailSchema(Schema):
     pro_rooms: int = Field(..., description="방 갯수")
     pro_bathrooms: int = Field(..., description="욕실 갯수")
     pro_construction_year: int = Field(..., description="건축연도")
+    add_new: str = Field(..., description="도로명주소")
+    add_old: str = Field(..., description="구주소")
+    latitude: float = Field(..., description="위도")
+    longitude: float = Field(..., description="경도")
 
 
-class ImageSchema(Schema):
-    img_url: str
-
-
-class VideoSchema(Schema):
-    video_url: str
-
-
-# 매물등록 api request body 스키마
-class ProductAllSchema(Schema):
-    detail: ProductDetailSchema
-    address: AddressSchema
-
-
-# 매물등록 api response 스키마
-class ProductAllResponseSchema(Schema):
-    success: bool
-    message: str
+# 매물생성 응답데이터 *상세* 스키마
+class ProductResponseDetailSchema(Schema):
     product_id: int
     images: list[str]
     video: Optional[str] = None
-    detail: ProductDetailSchema
-    address: AddressSchema
+    pro_title: str = Field(..., description="제목")
+    pro_price: int = Field(..., description="매물금액")
+    management_cost: Optional[int] = Field(default=None, description="관리비")
+    pro_supply_a: float = Field(..., description="공급면적(평수)")
+    pro_site_a: float = Field(..., description="부지면적")
+    pro_heat: HeatType = Field(..., description="난방방식")
+    pro_type: BuildingType = Field(..., description="건물유형")
+    pro_floor: int = Field(..., description="층")
+    description: str = Field(..., description="상세설명")
+    sale: Optional[bool] = Field(default=True, description="판매여부")
+    pro_rooms: int = Field(..., description="방 갯수")
+    pro_bathrooms: int = Field(..., description="욕실 갯수")
+    pro_construction_year: int = Field(..., description="건축연도")
+    add_new: str = Field(..., description="도로명주소")
+    add_old: str = Field(..., description="구주소")
+    latitude: float = Field(..., description="위도")
+    longitude: float = Field(..., description="경도")
     created_at: datetime = Field(..., description="등록일")
     updated_at: datetime = Field(..., description="수정일")
 
 
-class ProductUpdateResponseSchema(Schema):
+# 매물 등록 api response 스키마
+class ProductAllResponseSchema(Schema):
     success: bool
     message: str
+    product: ProductResponseDetailSchema
+
+
+# 매물수정 응답데이터 *상세* 스키마
+class ProductUpdateResponseDetailSchema(Schema):
     product_id: int
     images: Optional[list[str]] = None
     video: Optional[str] = None
-    detail: ProductDetailSchema
-    address: AddressSchema
+    pro_title: str = Field(..., description="제목")
+    pro_price: int = Field(..., description="매물금액")
+    management_cost: Optional[int] = Field(default=None, description="관리비")
+    pro_supply_a: float = Field(..., description="공급면적(평수)")
+    pro_site_a: float = Field(..., description="부지면적")
+    pro_heat: HeatType = Field(..., description="난방방식")
+    pro_type: BuildingType = Field(..., description="건물유형")
+    pro_floor: int = Field(..., description="층")
+    description: str = Field(..., description="상세설명")
+    sale: Optional[bool] = Field(default=True, description="판매여부")
+    pro_rooms: int = Field(..., description="방 갯수")
+    pro_bathrooms: int = Field(..., description="욕실 갯수")
+    pro_construction_year: int = Field(..., description="건축연도")
+    add_new: str = Field(..., description="도로명주소")
+    add_old: str = Field(..., description="구주소")
+    latitude: float = Field(..., description="위도")
+    longitude: float = Field(..., description="경도")
     created_at: datetime = Field(..., description="등록일")
     updated_at: datetime = Field(..., description="수정일")
 
 
+# 매물수정 api response 스키마
+class ProductUpdateResponseSchema(Schema):
+    success: bool
+    message: str
+    product: ProductUpdateResponseDetailSchema
+
+
+# 찜하기 api response 스키마
 class ProductLikeResponseSchema(Schema):
     success: bool
     message: str
@@ -100,19 +118,19 @@ class ProductLikeResponseSchema(Schema):
     )  # None 허용
 
 
+# 유저가 찜한 매물 목록 조회 스키마
 class UserLikedProductsSchema(Schema):
     product_id: int = Field(..., description="매물 ID")
     pro_title: str = Field(..., description="매물 제목")
     pro_price: int = Field(..., description="매물 가격")
     pro_type: str = Field(..., description="건물 유형")
     pro_supply_a: float = Field(..., description="공급면적")
-    pro_address: str = Field(..., description="매물 주소(도로명)")
-    image_url: Optional[str] = Field(
-        None, description="매물 이미지 URL(첫 번째 이미지)"
-    )
+    add_new: str = Field(..., description="매물 주소(도로명)")
+    images: Optional[str] = Field(None, description="매물 이미지 URL(첫 번째 이미지)")
     created_at: datetime = Field(..., description="찜한 시간")
 
 
+# 유저가 찜한 매물 목록 조회 응답 스키마
 class UserLikedProductsResponseSchema(Schema):
     success: bool = Field(..., description="요청 처리 성공 여부")
     message: str = Field(..., description="응답 메시지")
@@ -120,21 +138,21 @@ class UserLikedProductsResponseSchema(Schema):
     products: list[UserLikedProductsSchema] = Field(..., description="찜한 매물 목록")
 
 
-# 매물 상세 정보만을 위한 새로운 스키마
-class ProductDetailResponseSchema(Schema):
-    product_id: int
-    images: list[str]
-    video: Optional[str] = None
-    detail: ProductDetailSchema
-    address: AddressSchema
-    created_at: datetime = Field(..., description="등록일")
-    updated_at: datetime = Field(..., description="수정일")
+# 유저가 등록한 매물 목록 조회 스키마
+class MyProductsSchema(Schema):
+    product_id: int = Field(..., description="매물 ID")
+    pro_title: str = Field(..., description="매물 제목")
+    pro_price: int = Field(..., description="매물 가격")
+    pro_type: str = Field(..., description="건물 유형")
+    pro_supply_a: float = Field(..., description="공급면적")
+    add_new: str = Field(..., description="매물 주소(도로명)")
+    images: Optional[str] = Field(None, description="매물 이미지 URL(첫 번째 이미지)")
+    created_at: datetime = Field(..., description="찜한 시간")
 
 
-class UserProductsResponseSchema(Schema):
+# 유저가 등록한 매물 목록 조회 응답 스키마
+class MyProductsSchemaResponseSchema(Schema):
     success: bool = Field(..., description="요청 처리 성공 여부")
     message: str = Field(..., description="응답 메시지")
     total_count: int = Field(..., description="전체 등록 매물 수")
-    products: list[ProductDetailResponseSchema] = Field(
-        ..., description="등록한 매물 목록"
-    )
+    products: list[MyProductsSchema] = Field(..., description="등록한 매물 목록")


### PR DESCRIPTION
수정 목록:
1. `django/a_apis/api/products.py`
2. `django/a_apis/schema/products.py`
3. `django/a_apis/service/products.py`

수정 내용:
1. `django/a_apis/api/products.py`:
    - `ProductAllSchema`를 `ProductRequestBodySchema`로 변경.
    - `UserProductsResponseSchema`를 `MyProductsSchemaResponseSchema`로 변경.
    - `pro_address`를 `add_new`로 변경.
    - `image_url`를 `images`로 변경.
    - 추가된 스키마 필드 및 응답 스키마 상세정보 추가.

2. `django/a_apis/schema/products.py`:
    - `ProductAllSchema`를 `ProductRequestBodySchema`로 변경.
    - `AddressSchema`와 `AddressResponseSchema` 삭제.
    - `ProductResponseDetailSchema`, `ProductUpdateResponseDetailSchema`, `MyProductsSchema`, `MyProductsSchemaResponseSchema` 추가.
    - 기존 `ProductDetailResponseSchema` 삭제.
    - `pro_address` 변경.
    - `image_url`를 `images`로 변경.

3. `django/a_apis/service/products.py`:
    - `AddressSchema` 삭제.
    - `ProductAllSchema`를 `ProductRequestBodySchema`로 변경.
    - `UserProductsResponseSchema`를 `MyProductsSchemaResponseSchema`로 변경.
    - `pro_address` 변경.
    - `image_url`를 `images`로 변경.
    - `create_product`, `update_product`, `mylist_products` 메서드 수정.

특이사항:
- `AddressSchema`와 관련된 모든 필드가 `ProductRequestBodySchema`로 통합
- `ProductAllSchema`가 `ProductRequestBodySchema`로 대체
- `UserProductsResponseSchema`가 `MyProductsSchemaResponseSchema`로 대체
- `pro_address` 필드가 `add_new`로 변경
- `image_url` 필드가 `images`로 변경
