### PR TITLE
274 fix move if directives inside server block in nginxconf

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -59,6 +59,16 @@ http {
         resolver 8.8.8.8 8.8.4.4 valid=300s;
         resolver_timeout 5s;
 
+        # 비정상적인 요청 차단
+        if ($request_uri ~* "(\.php|\.asp|\.exe|\.pl|\.cgi|\.scgi)$") {
+            return 444;
+        }
+
+        # 비정상적인 HTTP 메서드 차단
+        if ($request_method !~ ^(GET|HEAD|POST|PUT|DELETE|OPTIONS)$) {
+            return 444;
+        }
+
         location / {
             proxy_pass http://web_backend;
             proxy_set_header Host $host;
@@ -97,15 +107,5 @@ http {
     map $http_upgrade $connection_upgrade {
         default upgrade;
         '' close;
-    }
-
-    # 비정상적인 요청 차단
-    if ($request_uri ~* "(\.php|\.asp|\.exe|\.pl|\.cgi|\.scgi)$") {
-        return 444;
-    }
-
-    # 비정상적인 HTTP 메서드 차단
-    if ($request_method !~ ^(GET|HEAD|POST|PUT|DELETE|OPTIONS)$) {
-        return 444;
     }
 }


### PR DESCRIPTION
주요 변경사항:
비정상적인 요청 차단과 HTTP 메서드 차단을 위한 if 구문을 server 블록 내부로 이동
WebSocket 설정은 map 지시어를 사용하므로 http 블록 내에 그대로 유지