### PR TITLE
Fix: Remove the password from withdrawal(#282)

### DIFF
--- a/django/a_apis/api/users.py
+++ b/django/a_apis/api/users.py
@@ -98,7 +98,7 @@ def verify_email(request, data: EmailVerificationSchema):
 
 
 @router.delete("/withdraw", response=ErrorResponseSchema)
-def withdraw(request, data: WithdrawalSchema):
+def withdraw(request):
     """
     회원 탈퇴 엔드포인트
     """

--- a/django/a_apis/service/users.py
+++ b/django/a_apis/service/users.py
@@ -285,7 +285,7 @@ class UserService:
             )
 
     @staticmethod
-    def withdraw_user(request, data: WithdrawalSchema):
+    def withdraw_user(request):
         try:
             user = request.auth
             if not user:
@@ -311,17 +311,6 @@ class UserService:
                         "message": "인증되지 않은 사용자입니다.",
                     },
                 )
-
-            # 비밀번호 확인
-            if not user.is_social_login:
-                if not user.check_password(data.password):
-                    return Response(
-                        status=400,
-                        data={
-                            "success": False,
-                            "message": "비밀번호가 일치하지 않습니다.",
-                        },
-                    )
 
             # 소프트 딜리트 처리
             user.is_active = False


### PR DESCRIPTION
- Updated the `withdraw` function in `users.py` to eliminate the `data` parameter, simplifying the endpoint.
- Adjusted the `withdraw_user` method in `UserService` to remove the `data` parameter and related password check logic, streamlining the user withdrawal process.